### PR TITLE
For some circuits the qubits have None index. In this case, extract qubit indices a different way

### DIFF
--- a/itensornetworks_qiskit/graph.py
+++ b/itensornetworks_qiskit/graph.py
@@ -19,7 +19,12 @@ def cmap_from_circuit(qc: QuantumCircuit):
         if len(gate.qubits) >= 3:
             raise NotImplemented("Please transpile to only 1 and 2 qubit gates")
         if len(gate.qubits) == 2:
-            edges.append([gate.qubits[0]._index, gate.qubits[1]._index])
+            q0 = gate.qubits[0]
+            q1 = gate.qubits[1]
+            qubit_pair = [q0._index, q1._index]
+            if qubit_pair == [None, None]:
+                qubit_pair = [qc.layout.initial_layout[q0], qc.layout.initial_layout[q1]]
+            edges.append(qubit_pair)
     unique_edges = [list(s) for s in set([frozenset(item) for item in edges])]
     return unique_edges
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,0 +1,21 @@
+import unittest
+
+from qiskit import QuantumCircuit, transpile
+from qiskit.providers.fake_provider import GenericBackendV2
+
+from itensornetworks_qiskit.graph import cmap_from_circuit
+
+
+class TestCmapFromCircuit(unittest.TestCase):
+    def test_given_qc_with_no_qubit_indices_then_valid_edges_still_returned(self):
+        qc = QuantumCircuit(4)
+        edges = [[0, 1], [0, 2], [0, 3], [1, 3]]
+        for edge in edges:
+            qc.cx(edge[0], edge[1])
+        backend = GenericBackendV2(4, coupling_map=edges)
+        qc = transpile(qc, basis_gates=["rx", "ry", "rz", "cx"], backend=backend)
+        for gate in qc:
+            for qubit in gate.qubits:
+                qubit._index = None
+
+        self.assertEqual(sorted(cmap_from_circuit(qc)), edges)


### PR DESCRIPTION
This issue occurred when I loaded a serialised circuit, which I am unsure why it had `None` for the qubit indices in the gates. Nevertheless this fixes such an issue if it's encountered and I created a test that fails without the new fix